### PR TITLE
Fixed installation instructions and package home line, fixes #22

### DIFF
--- a/R/getData.R
+++ b/R/getData.R
@@ -3,7 +3,7 @@
 #' @return json string containing bioconductor package details
 #'
 #' @importFrom jsonlite toJSON
-#' 
+#'
 #' @export
 #'
 #' @examples
@@ -35,8 +35,12 @@ process_data <- function(pkg_list, raw_dl_stats) {
     dl_stats <- summarise_dl_stats(raw_dl_stats)
 
     pkg_link <- function(pkg) {
-        stringr::str_interp(
-            "http://bioconductor.org/packages/release/bioc/html/${pkg}.html"
+        vapply(
+            pkg,
+            function(x) {
+                stringr::str_interp("http://bioconductor.org/packages/release/bioc/html/${x}.html")
+            },
+            character(1)
         )
     }
 

--- a/inst/htmlwidgets/lib/bioc_explore/bubblechart.js
+++ b/inst/htmlwidgets/lib/bioc_explore/bubblechart.js
@@ -270,7 +270,11 @@ function drawBubblePlot(el, width, height, data, top, reformat_data) {
         fillSection("downloads", "Downloads Last Month", downloads_month);
         fillSection("license", "License", license);
         fillSection("authors", "Authors", authors);
-        fillSection("install", "Install", "source(\"https:// bioconductor.org/biocLite.R\")<br />biocLite(\"" + name + "\")");
+        fillSection("install", "Install", 
+            `if (!requireNamespace("BiocManager", quietly = TRUE))<br />` +
+            `&nbsp;&nbsp;&nbsp;&nbsp;install.packages("BiocManager")<br />` +
+            `BiocManager::install("${name}", version = "3.8")`
+        );
     
         d3.select("div.info-box")
             .select(".row.page")


### PR DESCRIPTION
* Updated installation instructions to use BiocManager::install()
* Fixed package home links to not always point to a4

Wrongly assumed that `dplyr::mutate()` worked element-wise, it feeds in the whole column and `stringr::str_interp()` will only use the first element, which was a4.