### PR TITLE
Added new filter "None", set as default

### DIFF
--- a/inst/htmlwidgets/lib/bioc_explore/bubblechart.js
+++ b/inst/htmlwidgets/lib/bioc_explore/bubblechart.js
@@ -174,18 +174,20 @@ function drawBubblePlot(el, width, height, data, top, reformat_data) {
                         .style("position", "absolute")
                         .style("top", "10px")
                         .style("left", "10px");
-    
+        
+        outer.append("div")
+            .html("Filter:");
         var inner = outer.append("select");
     
+        inner.append("option")
+            .attr("value", "None")
+            .html("None")
+            .attr("selected", "");
+
         for (let tag of allTags.sort()) {
             var opt = inner.append("option")
                 .attr("value", tag)
                 .html(tag);
-
-            // default selection is "Software"
-            if (tag === "Software") {
-                opt.attr("selected", "");
-            }
         }
 
         inner.on("change", function() { filterByTag(this.value); });
@@ -327,7 +329,11 @@ function drawBubblePlot(el, width, height, data, top, reformat_data) {
     }
     
     function filterByTag(tag) {
-        partialData = tagFilter(data, tag);
+        if (tag == "None") {
+            partialData = data;
+        } else {
+            partialData = tagFilter(data, tag);
+        }
         partialData = topFilter(partialData, top)
         drawChart(partialData);
     }


### PR DESCRIPTION
* Added filter option "None" to biocExplore()
* Changed default filter to be "None"

Every package used to have biocView tag "Software", so this used to be the default and a lazy equivalent of no filtering. When the widget first loads it is actually not filtered by tag, but "Software" appears as the filter which used to equivalent. Now that "Software" is no longer a tag for everything, filtering on "Software" gives a different result than the initial graphic.

So I added "None" and made the the default startup filter, as well as be available for later use. Thanks @mritchie for spotting this!