### PR TITLE
 Fixed biocBuildReport to work with n number of builders

### DIFF
--- a/R/biocBuildReport.R
+++ b/R/biocBuildReport.R
@@ -63,7 +63,8 @@ biocBuildReport <- function(version=as.character(BiocManager::version())) {
   y = rex::re_matches(pkgnames,
                       rex(
                         start,
-                        capture(any_alnums, name='pkg'),
+                        # matches .standard_regexps()$valid_package_name
+                        capture(alpha,any_of(alnum,"."),alnum, name = "pkg"),
                         maybe(any_blanks),
                         capture(except_any_of(any_alphas),name="version"),
                         maybe(any_blanks),

--- a/R/biocBuildReport.R
+++ b/R/biocBuildReport.R
@@ -66,7 +66,8 @@ biocBuildReport <- function(version=as.character(BiocManager::version())) {
                         # matches .standard_regexps()$valid_package_name
                         capture(alpha,any_of(alnum,"."),alnum, name = "pkg"),
                         maybe(any_blanks),
-                        capture(except_any_of(any_alphas),name="version"),
+                        # matches .standard_regexps()$valid_package_version
+                        capture(between(group(digits,character_class(".-")),1,""),digits, name = "version"),
                         maybe(any_blanks),
                         capture(anything,name='author'),
                         "Last",anything,"Commit:",

--- a/R/biocBuildReport.R
+++ b/R/biocBuildReport.R
@@ -55,7 +55,9 @@ biocBuildReport <- function(version=as.character(BiocManager::version())) {
   dat = xml2::read_html(sprintf('http://bioconductor.org/checkResults/%s/bioc-LATEST/',version))
   
   rowspan = length(html_text(html_nodes(dat,xpath='/html/body/table[@class="node_specs"]/tr[@class!=""]')))
-  
+  if(rowspan > 5L || rowspan < 2L){
+    warning("Detected an unusual number of builders == ",rowspan," ... ")
+  }
   pkgnames = html_text(html_nodes(dat,xpath=sprintf('/html/body/table[@class="mainrep"]/tr/td[@rowspan="%s"]',rowspan)))
   
   y = rex::re_matches(pkgnames,

--- a/R/problemPage.R
+++ b/R/problemPage.R
@@ -9,9 +9,16 @@ checkMe = function(ver="devel", authorPattern="V.*Carey", includeOK = FALSE) {
  if (nrow(bad)>0) return(bad[,-c(3,4,5)]) else return(NULL)
 }
  
-chkURL = function(ver="devel", pack="BiocOncoTK",
-   node="malbec1", stage="buildsrc")
-  sprintf("https://bioconductor.org/checkResults/%s/bioc-LATEST/%s/%s-%s.html", ver, pack, node, stage)
+chkURL = function(ver="devel", result = "ERROR", pack="BiocOncoTK",
+   node="malbec1", stage="buildsrc"){
+  urls <- rep("",length(ver))
+  skipped <- result == "skipped"
+  urls[!skipped] <- sprintf("https://bioconductor.org/checkResults/%s/bioc-LATEST/%s/%s-%s.html", 
+                            ver[!skipped], pack[!skipped], node[!skipped], stage[!skipped])
+  urls[skipped] <- sprintf("https://bioconductor.org/checkResults/%s/bioc-LATEST/%s/", 
+                           ver[skipped], pack[skipped])
+  urls
+}
 
 #' generate hyperlinked HTML for build reports for Bioc packages
 #'
@@ -42,7 +49,8 @@ problemPage = function(authorPattern="V.*Carey", ver="devel", includeOK = FALSE)
     mm = checkMe(authorPattern=authorPattern, ver=ver, includeOK = includeOK)
     nn = nrow(mm)
     if (is.null(nn)) stop("all packages fine")
-    cc = chkURL(mm[["bioc_version"]], mm[["pkg"]], mm[["node"]], mm[["stage"]])
+    cc = chkURL(mm[["bioc_version"]], mm[["result"]], mm[["pkg"]], mm[["node"]],
+                mm[["stage"]])
     hr = lapply(seq_len(nrow(mm)), function(x)
         htmltools::a(mm[x, "pkg"], href=cc[[x]]))
     col1 = unlist(lapply(hr, as.character))

--- a/R/problemPage.R
+++ b/R/problemPage.R
@@ -12,7 +12,7 @@ checkMe = function(ver="devel", authorPattern="V.*Carey", includeOK = FALSE) {
 chkURL = function(ver="devel", result = "ERROR", pack="BiocOncoTK",
    node="malbec1", stage="buildsrc"){
   urls <- rep("",length(ver))
-  skipped <- result == "skipped"
+  skipped <- result %in% c("skipped","NA")
   urls[!skipped] <- sprintf("https://bioconductor.org/checkResults/%s/bioc-LATEST/%s/%s-%s.html", 
                             ver[!skipped], pack[!skipped], node[!skipped], stage[!skipped])
   urls[skipped] <- sprintf("https://bioconductor.org/checkResults/%s/bioc-LATEST/%s/", 

--- a/tests/testthat/test_biocBuildReport.R
+++ b/tests/testthat/test_biocBuildReport.R
@@ -9,7 +9,7 @@ test_that("catch non-character version parameter ", {
 })
 
 test_that("nrow is correct", {
-  expect_equal(nrow(bioc3.5_build), 14913)
+  expect_equal(nrow(bioc3.5_build), 15003)
 })
 
 test_that("ncol is correct", {


### PR DESCRIPTION
Hi

Accessing Bioc devel build reports doesn't seem to work right now. The error is due to the result `tibble` containing no rows, since the number of builders is not 3 or 4

![image](https://user-images.githubusercontent.com/17824332/72671027-bc538a00-3a44-11ea-9bc7-8386223521c3.png)


```
library(BiocPkgTools)
#> Loading required package: htmlwidgets
    biocBuildReport("devel")
#> Error in `[[<-.data.frame`(`*tmp*`, "bioc_version", value = "devel"): replacement has 1 row, data has 0
problemPage(authorPattern = "V.*Carey", ver = "devel", includeOK = FALSE)
#> Error in `[[<-.data.frame`(`*tmp*`, "bioc_version", value = "devel"): replacement has 1 row, data has 0
```

With this PR the number of rows is dynamically detected from the table with the class `node_specs`.


<details>
<summary>Session info</summary>

```
> sessionInfo()
R version 3.6.2 (2019-12-12)
Platform: x86_64-w64-mingw32/x64 (64-bit)
Running under: Windows 10 x64 (build 18363)

Matrix products: default

locale:
[1] LC_COLLATE=German_Germany.1252  LC_CTYPE=German_Germany.1252    LC_MONETARY=German_Germany.1252 LC_NUMERIC=C                   
[5] LC_TIME=German_Germany.1252    

attached base packages:
[1] stats     graphics  grDevices utils     datasets  methods   base     

other attached packages:
[1] BiocPkgTools_1.4.0 htmlwidgets_1.5.1 

loaded via a namespace (and not attached):
 [1] Rcpp_1.0.3          compiler_3.6.2      pillar_1.4.3        BiocManager_1.30.10 bitops_1.0-6        tools_3.6.2        
 [7] zeallot_0.1.0       digest_0.6.23       lifecycle_0.1.0     jsonlite_1.6        tibble_2.1.3        pkgconfig_2.0.3    
[13] rlang_0.4.2         graph_1.64.0        rex_1.1.2           igraph_1.2.4.2      cli_2.0.1           rstudioapi_0.10    
[19] curl_4.3            parallel_3.6.2      stringr_1.4.0       dplyr_0.8.3         httr_1.4.1          xml2_1.2.2         
[25] vctrs_0.2.1         hms_0.5.3           stats4_3.6.2        DT_0.11             tidyselect_0.2.5    glue_1.3.1         
[31] Biobase_2.46.0      R6_2.4.1            gh_1.0.1            fansi_0.4.1         XML_3.98-1.20       RBGL_1.62.1        
[37] tidyr_1.0.0         purrr_0.3.3         readr_1.3.1         magrittr_1.5        backports_1.1.5     htmltools_0.4.0    
[43] biocViews_1.54.0    BiocGenerics_0.32.0 rvest_0.3.5         RUnit_0.4.32        assertthat_0.2.1    utf8_1.1.4         
[49] stringi_1.4.4       lazyeval_0.2.2      RCurl_1.95-4.12     crayon_1.3.4 
```
</details>