### PR TITLE
More gentle handling of some errors by biocPkgList() and pkg*() functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: BiocPkgTools
 Type: Package
 Title: Collection of simple tools for learning about Bioc Packages
-Version: 1.5.6
-Date: 2020-03-14
+Version: 1.5.7
+Date: 2020-03-19
 Authors@R: c( 
     person("Shian", "Su", role=c("aut", "ctb"), email = "su.s@wehi.edu.au"),
     person("Lori", "Shepherd", role="ctb", email = "Lori.Shepherd@roswellpark.org"),
@@ -49,7 +49,7 @@ Imports:
     magrittr
 VignetteBuilder: knitr
 Suggests: BiocStyle, knitr, rmarkdown,
-    testthat, tm, SnowballC, pdftools,
+    testthat, tm, SnowballC,
     visNetwork, clipr, blastula, kableExtra
 License: MIT + file LICENSE
 BugReports: https://github.com/seandavi/BiocPkgTools/issues/new

--- a/R/biocPkgList.R
+++ b/R/biocPkgList.R
@@ -76,9 +76,7 @@ biocPkgList = function(version = BiocManager::version(), repo='BioCsoft',
     repos <- BiocManager:::.repositories(site_repository=NA, version = version)
     mask <- !repo %in% names(repos)
     if (any(mask))
-      warning(sprintf("repo %s not found in known repositories. Valid values",
-                      "for repo can be shown by running",
-                      "names(BiocManager::repositories()).",
+      warning(sprintf("repo %s not found in known repositories. Valid values for repo can be shown by running names(BiocManager::repositories()).",
                       paste(repo[mask], collapse=", ")))
     if (all(mask))
       stop("No repo was found in known repositories.")

--- a/man/pkgDepImports.Rd
+++ b/man/pkgDepImports.Rd
@@ -7,13 +7,31 @@
 pkgDepImports(pkg)
 }
 \arguments{
-\item{pkg}{character() name of the packge for which we want
-to obtain metrics on its dependency burden.}
+\item{pkg}{character() name of the package for which we want
+to obtain the functionality calls imported from its dependencies
+and used within the package.}
 }
 \value{
-A tidy data frame with different metrics on the
-package dependency burden.
+A tidy data frame with two columns:
+\itemize{
+\item \code{pkg}: name of the package dependency.
+\item \code{fun}: name of the functionality call imported from the
+the dependency in the column \code{pkg} and used within
+the analyzed package.
+}
 }
 \description{
 Function adapted from 'itdepends::dep_usage_pkg' at https://github.com/r-lib/itdepends
+to obtain the functionality imported and used by a given package.
+}
+\details{
+Certain imported elements, such as built-in constants, will not
+be identified as imported functionality by this function.
+}
+\examples{
+pkgDepImports('BiocPkgTools')
+
+}
+\author{
+Robert Castelo
 }

--- a/man/pkgDepMetrics.Rd
+++ b/man/pkgDepMetrics.Rd
@@ -11,12 +11,56 @@ pkgDepMetrics(pkg, depdf)
 to obtain metrics on its dependency burden.}
 
 \item{depdf}{a tidy data frame with package dependency information
-obtained through the function \code{\link{buildPkgDependencyDataFrame}}}
+obtained through the function \code{\link{buildPkgDependencyDataFrame}}.}
 }
 \value{
 A tidy data frame with different metrics on the
-package dependency burden.
+package dependency burden. More concretely, the following columns:
+\itemize{
+\item \code{ImportedAndUsed}: number of functionality calls imported and used in
+the package.
+\item \code{Exported}: number of functionality calls exported by the dependency.
+\item \code{Usage}: (\code{ImportedAndUsed}x 100) / \code{Exported}. This value provides an
+estimate of what fraction of the functionality of the dependency is
+actually used in the given package.
+\item \code{DepOverlap}: Similarity between the dependency graph structure of the
+given package and the one of the dependency in the corresponding row,
+estimated as the \href{https://en.wikipedia.org/wiki/Jaccard_index}{Jaccard index}
+between the two sets of vertices of the corresponding graphs. Its values
+goes between 0 and 1, where 0 indicates that no dependency is shared, while
+1 indicates that the given package and the corresponding dependency depend
+on an identical subset of packages.
+\item \code{DepGainIfExcluded}: The 'dependency gain' (decrease in the total number
+of dependencies) that would be obtained if this package was excluded
+from the list of direct dependencies.
+}
+
+The reported information is ordered by the \code{Usage} column to facilitate the
+identification of dependencies for which the analyzed package is using a small
+fraction of their functionality and therefore, it could be easier remove them.
+To aid in that decision, the column \code{DepOverlap} reports the overlap of the
+dependency graph of each dependency with the one of the analyzed package. Here
+a value above, e.g., 0.5, could, albeit not necessarily, imply that removing
+that dependency could substantially lighten the dependency burden of the analyzed
+package.
+
+An \code{NA} value in the \code{ImportedAndUsed} column indicates that the function
+\code{pkgDepMetrics()} could not identify what functionality calls in the analyzed
+package are made to the dependency.
 }
 \description{
 Elaborate a report on the dependency burden of a given package.
+}
+\examples{
+depdf <- buildPkgDependencyDataFrame(
+  dependencies=c("Depends", "Imports"), 
+  repo=c("BioCsoft", "CRAN")
+)
+pkgDepMetrics('BiocPkgTools', depdf)
+
+}
+\author{
+Robert Castelo
+
+Charlotte Soneson
 }

--- a/vignettes/BiocPkgTools.Rmd
+++ b/vignettes/BiocPkgTools.Rmd
@@ -319,8 +319,8 @@ An `NA` value in the `ImportedAndUsed` column indicates that the function
 `pkgDepMetrics()` could not identify what functionality calls in the analyzed
 package are made to the dependency. This may happen because `pkgDepMetrics()`
 has failed to identify the corresponding calls, as it happens with imported
-constants such as `DNA_BASES` from `Biostrings`, or that although the given
-package is importing that dependency, none of its functionality is actually
+built-in constants such as `DNA_BASES` from `Biostrings`, or that although the
+given package is importing that dependency, none of its functionality is actually
 being used. In such a case, this dependency could be safely removed without
 any further change in the analyzed package.
 


### PR DESCRIPTION
More gentle handling of some errors by biocPkgList(), pkgDepMetrics() and pkgCombDependencyGain() and improved documentation for pkgDepImports() and pkgDepMetrics(). In the case of 'biocPkgList()', when a 'repo' is misspecified and does not exist. In the case of the other functions, when the given package is misspecified and does not form part of the package information from the repositories. It builds and checks clean in the latest R-devel.