### PR TITLE
remove sender_name from blastula::creds

### DIFF
--- a/R/biocBuildEmail.R
+++ b/R/biocBuildEmail.R
@@ -245,7 +245,6 @@ biocBuildEmail <-
                     blastula::creds(
                         user = paste0(core.id, "@roswellpark.org"),
                         provider = "office365",
-                        sender_name = core.name,
                         use_ssl = FALSE
                     )
             )


### PR DESCRIPTION
Minor change to `blastula::creds`, merge to update 
Thanks! @seandavi 