### PR TITLE
Fix problems in biocBuildReport

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: BiocPkgTools
 Type: Package
 Title: Collection of simple tools for learning about Bioc Packages
-Version: 1.7.1.9001
-Date: 2020-10-12
+Version: 1.9.1
+Date: 2020-02-24
 Authors@R: c( 
     person("Shian", "Su", role=c("aut", "ctb"), email = "su.s@wehi.edu.au"),
     person("Lori", "Shepherd", role="ctb", email = "Lori.Shepherd@roswellpark.org"),

--- a/R/biocBuildReport.R
+++ b/R/biocBuildReport.R
@@ -59,7 +59,14 @@ biocBuildReport <- function(version=as.character(BiocManager::version())) {
   if(rowspan > 5L || rowspan < 2L){
     warning("Detected an unusual number of builders == ",rowspan," ... ")
   }
-  pkgnames = html_text(html_nodes(dat,xpath=sprintf('/html/body/table[@class="mainrep"]/tr/td[@rowspan="%s"]',rowspan)))
+  
+  ## the format of the build report page changed for BioC 3.12
+  ## might be better to check version with BiocManager:::.version_validate()
+  if(version %in% c("release", "devel") || numeric_version(version) > 3.11) {
+    pkgnames = html_text(html_nodes(dat,xpath=sprintf('/html/body/table[@id="THE_BIG_GCARD_LIST"]/tbody[contains(@class, "gcard")]/tr/td[@rowspan="%s"]', rowspan)))
+  } else { 
+    pkgnames = html_text(html_nodes(dat,xpath=sprintf('/html/body/table[@class="mainrep"]/tr/td[@rowspan="%s"]',rowspan)))
+  }
 
   y = re_matches(pkgnames,
                  rex(

--- a/tests/testthat/test_biocBuildReport.R
+++ b/tests/testthat/test_biocBuildReport.R
@@ -2,6 +2,7 @@ context("biocBuildReport")
 library(BiocPkgTools)
 
 bioc3.5_build = biocBuildReport("3.5")
+bioc3.12_build = biocBuildReport(version = "3.12")
 
 
 test_that("catch non-character version parameter ", {
@@ -10,8 +11,10 @@ test_that("catch non-character version parameter ", {
 
 test_that("nrow is correct", {
   expect_equal(nrow(bioc3.5_build), 15003)
+  expect_equal(nrow(bioc3.12_build), 27466)
 })
 
 test_that("ncol is correct", {
   expect_equal(ncol(bioc3.5_build), 9)
+  expect_equal(ncol(bioc3.12_build), 9)
 })


### PR DESCRIPTION
The format of the build report HTML has changed in BioC 3.12, and the existing code for `biocBuildReport()` returns and empty tibble.  This is also causing the current build failures on the BioC builder, as the unit tests fail.

This patch adds the required xpath for handling the new page layout and adds some unit tests based on those that already exist.