### PR TITLE
Update newBiocPkgDOI to use REST API

### DIFF
--- a/R/newBiocPkgDOI.R
+++ b/R/newBiocPkgDOI.R
@@ -1,32 +1,36 @@
 
 #' Generate a DOI for a Bioconductor package
 #'
-#' This function makes calls out to the EZID API (v2) described
-#' here: \url{https://ezid.lib.purdue.edu/doc/apidoc.2.html}. The
+#' This function makes calls out to the DataCite REST API described
+#' here: \url{https://support.datacite.org/docs/api-create-dois}. The
 #' function creates a new DOI for a Bioconductor package (cannot already
 #' exist). The target URL for the DOI is the short Bioconductor
 #' package URL.
 #'
 #' The login information for the "real" Bioconductor account
-#' should be stored in the environment variables "EZID_USERNAME"
-#' and "EZID_PASSWORD".
+#' should be stored in the environment variables "DATACITE_USERNAME"
+#' and "DATACITE_PASSWORD
 #'
 #' The GUI is available here: \url{https://doi.datacite.org/}.
 #'
 #' @param pkg character(1) package name
 #' @param authors character vector of authors (will be "pasted" together)
 #' @param pubyear integer(1) publication year
+#' @param event Either "hide", "register", or publish". Typically, we use
+#'     "publish" to make the DOI findable.
 #' @param testing logical(1) If true, will use the apitest
 #'     user with the password apitest. These DOIs will expire.
 #'     The same apitest:apitest combination can be used to
-#'     login to the EZID website for doing things using the
+#'     login to the website for doing things using the
 #'     web interface. If false, the Bioconductor-specific
 #'     user credentials should be in the correct environment
 #'     variables
 #'
 #' @return The DOI as a character(1) vector.
 #'
-#' @importFrom httr POST status_code PUT authenticate timeout content_type accept content
+#' @importFrom httr VERB content_type content add_headers
+#' @importFrom jsonlite toJSON
+#' @importFrom stringr str_to_upper
 #'
 #' @keywords Internal
 #'
@@ -34,43 +38,51 @@
 #' \dontrun{
 #'   x = generateBiocPkgDOI('RANDOM_TEST_PACKAGE','Sean Davis',1972)
 #' }
-generateBiocPkgDOI = function(pkg, authors, pubyear, testing=TRUE) {
-  if(testing) {
+generateBiocPkgDOI <- function(pkg, authors, pubyear, event = "publish", testing = TRUE) {
+
+  username <- Sys.getenv("DATACITE_USERNAME")
+  password <- Sys.getenv("DATACITE_PASSWORD")
+
+  if (!is.element(event, c("hide", "register", "publish")))
+    stop("event must be 'hide', 'register', or 'publish'.")
+
+  if (testing) {
     # View results at: https://doi.test.datacite.org
-    # The testing piece does not work with new API?
-    username='TESTING_USERNAME'
-    password='TESTING_PASSWORD'
-    bioc_shoulder='doi:10.5072/FK2'
-    base_url = 'https://ez.test.datacite.org/id'
+    bioc_prefix <- "10.22018"
+    base_url <- "https://api.test.datacite.org/dois"
   } else {
-    username=Sys.getenv('EZID_USERNAME')
-    password=Sys.getenv('EZID_PASSWORD')
-    bioc_shoulder='doi:10.18129/B9'
-    base_url = "https://ez.datacite.org/id"
+    bioc_prefix <- "10.18129"
+    base_url <- "https://api.datacite.org/dois"
   }
-  bioc_doi_namespace = ".bioc."
-  pkg_doi = paste0(bioc_shoulder,bioc_doi_namespace,pkg)
-  url0 = file.path(base_url,pkg_doi)
-  body = paste(c(sprintf("datacite.title: %s",pkg),
-                 sprintf("_target: https://bioconductor.org/packages/%s",pkg),
-                 sprintf("datacite.creator: %s",gsub('\n','',paste(authors,collapse=", "))),
-                 "datacite.publisher: Bioconductor",
-                 sprintf("datacite.publicationyear: %d",pubyear),
-                 sprintf("datacite.resourcetype: %s","Software")),collapse="\n")
-  res = httr::POST(url0,
-                  content_type('text/plain'),
-                  accept("text/plain"),
-                  httr::authenticate(username,password),
-                  body=body,timeout(30))
-  if(status_code(res)>=400) {
-    res = httr::PUT(url0,
-                     content_type('text/plain'),
-                     accept("text/plain"),
-                     httr::authenticate(username,password),
-                     body=body,timeout(30))
-  }
-  message(res)
-  return(res)
-  tmp = strsplit(content(res),' ')[[1]][c(2,4)]
-  return(tmp[1])
+
+  bioc_doi_namespace <- "bioc"
+  pkg_doi <- paste0(bioc_prefix, "/", bioc_doi_namespace, ".", pkg)
+  encode <- "raw"
+  payload <- list("data" = list("id" = paste0("https://doi.org/", pkg_doi),
+                                "doi" = stringr::str_to_upper(pkg_doi),
+                                "attributes" = list("doi" = pkg_doi,
+                                                    "event" = event,
+                                                    "prefix" = bioc_prefix,
+                                                    "suffix" = paste(bioc_doi_namespace, pkg, sep = "."),
+                                                    "identifiers" = list("identifier" = pkg_doi,
+                                                                         "identifierType" = "DOI"),
+                                                    "creators" = list("name" = paste(authors, collapse = ", ")),
+                                                    "titles" = list("title" = pkg),
+                                                    "url" = paste0("https://bioconductor.org/packages/", pkg),
+                                                    "publisher" = "Bioconductor",
+                                                    "publicationYear" = pubyear,
+                                                    "types" = list("resourceTypeGeneral" = "Software")
+                                                   )
+                                )
+                 )
+
+  authorization <- jsonlite::base64_enc(paste(username, password, sep = ":"))
+  response <- httr::VERB("POST",
+                         base_url,
+                         body = jsonlite::toJSON(payload, auto_unbox = TRUE),
+                         httr::add_headers(Authorization = paste("Basic", authorization, sep = " ")),
+                         httr::content_type("application/vnd.api+json"),
+                         encode = encode)
+
+  httr::content(response, "text")
 }


### PR DESCRIPTION
This PR updates the function `generateBiocPkgDOI` to use the REST API since the EZID API stopped last year. It constructs the data into JSON but is otherwise pretty similar to the old code. I did rename the username and password to `DATACITE_USERNAME` and `DATACITE_PASSWORD` since it seemed more appropriate. Also the DOIs will take the form of `10.18129/bioc.newtestpkg`--there's no more shoulder as in `a4`'s DOI: `10.18129/B9.bioc.a4`. I also added an `event` parameter, which we'll usually want to keep as the default `published` so that the DOI is findable.

Note: I only tested on the live site `https://api.datacite.org/dois` because I didn't know the test site password.

Tagging @vjcitn.