### PR TITLE
Add back 'B9' in DOI to match older Bioconductor packages

### DIFF
--- a/R/newBiocPkgDOI.R
+++ b/R/newBiocPkgDOI.R
@@ -55,7 +55,7 @@ generateBiocPkgDOI <- function(pkg, authors, pubyear, event = "publish", testing
     base_url <- "https://api.datacite.org/dois"
   }
 
-  bioc_doi_namespace <- "bioc"
+  bioc_doi_namespace <- "B9.bioc"
   pkg_doi <- paste0(bioc_prefix, "/", bioc_doi_namespace, ".", pkg)
   encode <- "raw"
   payload <- list("data" = list("id" = paste0("https://doi.org/", pkg_doi),


### PR DESCRIPTION
Although 'B9' is no longer needed (and was a consequence of the previous API), the DOI generated on Bioconductor package pages is automatically generated with 'B9' in the URL. This adds it back so that the DOI will resolve on the package pages.