### PR TITLE
Use message() rather than print()

### DIFF
--- a/R/getYearsInBioc.R
+++ b/R/getYearsInBioc.R
@@ -249,7 +249,7 @@ getPkgYearsInBioc <- function(pkglist = NULL) {
     }
     list_rbind(mapply(
         \(category, version) {
-            print(glue("{category} / {version}"))
+            message(glue("{category} / {version}"))
 
             con <- curl(glue(manifest_template))
             result <- read.dcf(con)


### PR DESCRIPTION
Would it be possible to use `message()` here please? I'm trying to not display the text and would like `message = FALSE` / `suppressMessages()` to work on this.