### PR TITLE
Fix biocBuildReport() silently dropping non-software packages

### DIFF
--- a/R/biocBuildReport.R
+++ b/R/biocBuildReport.R
@@ -141,7 +141,7 @@ biocBuildReport <- function(
       vapply(depdf, function(x) identical(length(x), 0L), logical(1L))
   )
   if (!isEmpty)
-      y <- merge(y, depdf, by.x = "pkg", by.y = "Package")
+      y <- merge(y, depdf, by.x = "pkg", by.y = "Package", all.x = TRUE)
 
   df <- suppressMessages(left_join(y, z)) # just suppress "Joining by...."
   df <- as_tibble(df)

--- a/tests/testthat/test_biocBuildReport.R
+++ b/tests/testthat/test_biocBuildReport.R
@@ -21,3 +21,17 @@ test_that("columns are consistent in report output", {
     expect_true(tibble::is_tibble(bioc3.14_build))
 })
 
+test_that("non-software package types are not dropped (#21)", {
+    full_build <- biocBuildReport(
+        "devel",
+        pkgType = c(
+            "software", "data-experiment", "data-annotation", "workflows"
+        )
+    )
+    reported_types <- unique(full_build[["pkgType"]])
+    expect_true(all(
+        c("data-annotation", "data-experiment", "workflows") %in%
+            reported_types
+    ))
+})
+


### PR DESCRIPTION
Fixes #21.

## Bug

`biocBuildReport()` requests all four package types by default (`software`, `data-experiment`, `data-annotation`, `workflows`), and `biocBuildReportDB()` correctly tags each row with its `pkgType`. But before returning, it joins in deprecation status:

```r
depdf <- get_deprecated_status_df(version)
...
if (!isEmpty)
    y <- merge(y, depdf, by.x = "pkg", by.y = "Package")
```

`get_deprecated_status_df()` always pulls only the software VIEWS file (`type = "BioCsoft"`), so `depdf` only ever contains software package names. `merge()`'s default `all = FALSE` makes this an **inner join**, which silently drops every row in `y` whose package isn't in the software VIEWS — i.e. every workflows/data-experiment/data-annotation row.

Net effect: `biocBuildReport()` (and everything built on it — `problemPage()`, `checkMe()`, `checkDeps()`) only ever reports on software packages, even though the `pkgType` parameter looks like it supports all four types. This is why #21 ("could problemPage also check workflow packages?") wasn't actually fixed by the existing `pkgType` support.

Verified live against Bioconductor devel (3.24):
- Before this fix: `biocBuildReport(version = "devel")` → 16772 rows, `table(pkgType)` is 100% `"bioc"`. The workflow package `annotation` (currently failing at `buildsrc`) is completely absent.
- After this fix: 18277 rows, with 144 `data-annotation`, 1305 `data-experiment`, and 56 `workflows` rows restored, including `annotation`'s real `ERROR` row.

## Fix

Change the merge to `all.x = TRUE` so non-software packages are preserved. `Deprecated`/`PackageStatus` are `NA` for those rows, since deprecation status for workflows/data-experiment/data-annotation packages isn't tracked by `get_deprecated_status_df()` today — that's a separate, smaller gap that could be closed later by pulling the VIEWS file per requested `pkgType`, but it's out of scope for restoring the missing rows. Nothing downstream (`problemPage.R`) filters on `Deprecated`/`PackageStatus`, so this is safe.

## Testing

- Added a test in `tests/testthat/test_biocBuildReport.R` asserting that `data-annotation`, `data-experiment`, and `workflows` all appear in `biocBuildReport("devel")$pkgType`.
- Ran the full `test_biocBuildReport.R` suite: `FAIL 0 | WARN 2 (pre-existing, unrelated) | PASS 10`.

## Note

No version bump included — this repo's convention (per recent history) is for the maintainer to bump `DESCRIPTION` right before merge, not as part of the contributing branch.